### PR TITLE
Fix worker-src CSP

### DIFF
--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -119,6 +119,7 @@ class PageController extends Controller {
 		$policy->addAllowedFontDomain('data:');
 		$policy->addAllowedFontDomain('blob:');
 		$policy->addAllowedImageDomain('blob:');
+		$policy->addAllowedWorkerSrcDomain('\'self\''); 
 
 		$response = new TemplateResponse($this->appName, $template, $params, 'blank');
 		$response->setContentSecurityPolicy($policy);


### PR DESCRIPTION
Add 'self' to worker-src in CSP header so Firefox doesn't block scripts loaded by archive.js

It made the app unusable on my Nextcloud 30 instance.